### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testcover.yml
+++ b/.github/workflows/testcover.yml
@@ -11,6 +11,8 @@ jobs:
   unit_tests:
     name: "Unit tests"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/horknfbr/traefikunifidns/security/code-scanning/1](https://github.com/horknfbr/traefikunifidns/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `unit_tests` job. Since the job only needs to read the repository contents and upload artifacts, we will set `contents: read` as the minimal required permission. This ensures that the job does not inherit unnecessary write permissions from the repository or organization defaults.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
